### PR TITLE
v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-09-15
+
+### General
+
+- v0.3.0 focuses on smoother app integration and orchestration across multiple canisters. It adds non-React helpers and global utilities so you can gate routes, authenticate many actors at once, and reliably check initialization/auth state without wiring extra context or providers. Docs now include a router-first flow.
+
+### Key Features
+- Unified runtime status: New `status` plus `isInitializing/isSuccess/isError`.
+- Non-React helpers: Call `ensureInitialized`, `authenticate`, `getActor`, and status predicates outside components.
+- Global orchestration: `ensureAllInitialized`, `authenticateAll`, and `authenticateCanister` coordinate many hooks.
+- Router integration docs: Example guard flow with TanStack Router for predictable startup and auth, no `useEffect` in sight.
+
+Example (route guard flow):
+```ts
+const identity = await ensureIdentityInitialized(); // from ic-use-internet-identity
+if (!identity) throw redirect({ to: "/login" });
+
+await ensureAllInitialized();     // wait for all actor hooks to finish anonymous init
+await authenticateAll(identity);  // attach identity to all registered hooks
+```
+
+### Added
+- Status + flags: `status: "initializing" | "success" | "error"` and derived booleans.
+- Per-hook helpers (non-React): `useMyActor.ensureInitialized()`, `useMyActor.authenticate(identity)`, `useMyActor.getActor()`, `useMyActor.isAuthenticated()` and predicates for status.
+- Global helpers: `ensureAllInitialized()`, `authenticateAll(identity, filter?)`, `authenticateCanister(identity, canisterId)`.
+- Router example: End-to-end “beforeLoad” example covering identity restore → actor init → authentication
+
+### Fixed
+- Docs clarity: Clear separation of initialization vs. authentication; `error` now documented as “initialization only”.
+- Interceptor ergonomics: Example shows handling “delegation expired” with app hooks, without polluting init error state.
+- Minor typos and examples: Cleaned and tightened API examples, consistent naming.
+
+### Migration
+- From v0.2.x → v0.3.0: No breaking changes. You can adopt:
+  - `status` and the derived flags for simpler UI state.
+  - Non-React helpers in guards, loaders, or services.
+  - Global helpers to authentically attach identity across many hooks at once.
+
+### Important Notes
+- Initialization vs auth: `isSuccess` means “actor created”; it does NOT imply authenticated. Check `isAuthenticated`.
+- Identity first: Always await your identity library’s init before initializing/authenticating actors in guards.
+- Auth is local: `authenticate(identity)` mutates the agent’s identity; it doesn’t perform a network request.
+- Multiple canisters: Either authenticate each hook or use `authenticateAll(identity)`; you can filter by canister id.
+- Errors: The exposed `error` is reserved for initialization failures; interceptor/auth errors won’t set it.
+
+
 ## [0.2.0] - 2025-08-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A React hook library for interacting with Internet Computer (IC) canisters. `ic-
   - [API Reference](#api-reference)
     - [createActorHook](#createactorhook)
     - [Hook Return Value](#hook-return-value)
+    - [Global Helpers](#global-helpers)
   - [Migration from v0.1.x](#migration-from-v01x)
   - [Examples](#examples)
   - [Author](#author)
@@ -479,6 +480,34 @@ Property summary
 | `setInterceptors` | `(interceptors: InterceptorOptions) => void` | Apply request/response interceptors to the actor |
 | `reset` | `() => void` | Reset the actor state and reinitialize |
 | `clearError` | `() => void` | Clear stored error state |
+
+### Global Helpers
+
+Helpers that operate across all registered hook instances (useful when your app creates multiple actor hooks):
+
+- `ensureAllInitialized(): Promise<void>` — waits for every registered hook to finish its initial anonymous setup. Useful in route guards where you want all actor hooks ready.
+
+- `authenticateAll(identity: Identity, filterCanisterIds?: string[]): Promise<void>` — attaches the provided identity to all registered hooks; if `filterCanisterIds` is supplied only hooks whose `canisterId` is included will be authenticated. Throws if any hook's authentication fails.
+
+- `authenticateCanister(identity: Identity, canisterId: string): Promise<void>` — convenience wrapper to authenticate hooks for a specific canister id.
+
+Example (router integration):
+
+```ts
+import { ensureAllInitialized, authenticateAll } from 'ic-use-actor';
+import { ensureInitialized as ensureIdentityInitialized } from 'ic-use-internet-identity';
+
+const identity = await ensureIdentityInitialized();
+if (!identity) throw redirect('/login');
+await ensureAllInitialized();
+await authenticateAll(identity);
+```
+
+
+### Notes on global helpers
+
+- `ensureAllInitialized` only waits for the initial anonymous `HttpAgent` + actor creation — it does not authenticate hooks.
+- `authenticateAll` will call each hook's `authenticate` helper which updates the per-hook `isAuthenticated` flag.
 
 ## Migration from v0.1.x
 

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ interface UseActorReturn<T> {
   // Authentication flag (separate from initialization)
   isAuthenticated: boolean; // whether an identity has been attached
 
-  // Any error that occurred during initialization or authentication
+  // Any error that occurred during initialization. Authentication and interceptor errors do not populate this field.
   error?: Error;
 
   // Helpers
@@ -475,7 +475,7 @@ Property summary
 | `isSuccess` | `boolean` | `status === "success"` (actor instance created) |
 | `isError` | `boolean` | `status === "error"` |
 | `isAuthenticated` | `boolean` | Whether an identity has been attached to the actor |
-| `error` | `Error | undefined` | Any error that occurred during initialization or authentication |
+| `error` | `Error | undefined` | Any error that occurred during initialization. Authentication and interceptor errors do not populate this field. |
 | `authenticate` | `(identity: Identity) => Promise<void>` | Attach an identity to the actor's agent |
 | `setInterceptors` | `(interceptors: InterceptorOptions) => void` | Apply request/response interceptors to the actor |
 | `reset` | `() => void` | Reset the actor state and reinitialize |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ic-use-actor",
-  "version": "0.2.0-beta.1",
+  "version": "0.2.0",
   "description": "React Hook and context provider to make interacting with Internet Computer canisters more fun!",
   "author": "Kristofer Lund <kristofer@kristoferlund.se>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ic-use-actor",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "React Hook and context provider to make interacting with Internet Computer canisters more fun!",
   "author": "Kristofer Lund <kristofer@kristoferlund.se>",
   "repository": {
@@ -45,6 +45,6 @@
     "esbuild": "^0.19.5",
     "npm-run-all": "^4.1.5",
     "react": "^18.2.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         specifier: ^18.2.0
         version: 18.3.1
       typescript:
-        specifier: ^5.2.2
+        specifier: ^5.8.3
         version: 5.9.2
 
 packages:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,31 +34,43 @@ export interface CreateActorHookOptions {
 }
 
 /**
+ * Actor status values (mirrors ic-use-internet-identity naming)
+ */
+export type ActorStatus =
+  | "initializing"
+  | "success"
+  | "error";
+
+/**
  * Store state for an actor
  */
 interface ActorStoreState<T> {
   actor: ActorSubclass<T> | undefined;
-  isInitializing: boolean;
-  isAuthenticated: boolean;
+  status: ActorStatus;
   error: Error | undefined;
+  isAuthenticated: boolean;
 }
 
 /**
  * Store events for an actor
  */
-interface ActorStoreEvents<T> {
-  setState: Partial<ActorStoreState<T>>;
-  reset: {};
-}
-
 /**
  * Return type of the useActor hook
  */
 export interface UseActorReturn<T> {
   /** The actor instance, initialized with anonymous agent by default */
   actor: ActorSubclass<T> | undefined;
-  /** Whether the actor is currently being initialized or authenticated */
+  /** Status of the actor initialization (initializing | success | error) */
+  status: ActorStatus;
+  /** `status === "initializing"` */
   isInitializing: boolean;
+  /** `status === "success"` — actor initialization completed successfully.
+   *  Note: this only indicates the actor was created; it does NOT imply the actor
+   *  has been authenticated with an identity. Use `isAuthenticated` to check whether
+   *  an identity has been attached. */
+  isSuccess: boolean;
+  /** `status === "error"` */
+  isError: boolean;
   /** Whether the actor is authenticated with a non-anonymous identity */
   isAuthenticated: boolean;
   /** Any error that occurred during initialization, authentication, or setting up interceptors */
@@ -131,85 +143,112 @@ function createInterceptorProxy<T>(
   });
 }
 
+// Registry for created hooks so we can operate across multiple instances
+type RegistryItem = {
+  id: number;
+  canisterId: string;
+  ensureInitialized: () => Promise<ActorSubclass<any> | undefined>;
+  /** Authenticate the hook instance with the provided Identity. */
+  authenticate: (identity: Identity) => Promise<void>;
+  getActor: () => ActorSubclass<any> | undefined;
+  isAuthenticated: () => boolean;
+};
+
+const hookRegistry = new Map<number, RegistryItem>();
+let nextHookId = 1;
+
 /**
  * Creates a React hook for interacting with an Internet Computer canister.
  * This hook manages the actor lifecycle and provides a simple interface for components.
  * The actor is initialized immediately with an anonymous agent, allowing unauthenticated calls.
  *
+ * Adds non-React helpers on the returned hook function so it can be used outside React
+ * (for example in route guards) and registers the hook in a module-level registry so
+ * multiple hooks can be authenticated en-masse.
+ *
  * @param options - Configuration options for the actor store
  * @returns A hook function that provides actor instance and control methods
+ */
+type ActorHook<T> = {
+  (): UseActorReturn<T>;
+  ensureInitialized: () => Promise<ActorSubclass<T> | undefined>;
+  authenticate: (identity: Identity) => Promise<void>;
+  getActor: () => ActorSubclass<T> | undefined;
+  isAuthenticated: () => boolean;
+  isInitializing: () => boolean;
+  isSuccess: () => boolean;
+  isError: () => boolean;
+};
+
+/**
+ * Factory that creates a React hook for interacting with an IC canister.
  *
- * @example
- * ```ts
- * // Setup in your actors file
- * import { createActorHook } from "ic-use-actor";
- * import { canisterId, idlFactory } from "./declarations/backend";
- * import { _SERVICE } from "./declarations/backend/backend.did";
- *
- * export const useBackendActor = createActorHook<_SERVICE>({
- *   canisterId,
- *   idlFactory,
- * });
- *
- * // Use in your components
- * function MyComponent() {
- *   const { actor, authenticate, isAuthenticated } = useBackendActor();
- *   const { identity } = useInternetIdentity();
- *
- *   // Authenticating is optional
- *   useEffect(() => {
- *     if (identity) {
- *       authenticate(identity);
- *     }
- *   }, [identity, authenticate]);
- *
- *   const handleClick = async () => {
- *     if (actor) {
- *       // Works with both anonymous and authenticated calls
- *       const result = await actor.someMethod();
- *       console.log(result);
- *     }
- *   };
- *
- *   return <button onClick={handleClick}>Call Method</button>;
- * }
- * ```
+ * The returned function is a React hook that provides the actor instance and
+ * utility methods for components. The function object itself also exposes
+ * non-React helpers (e.g. `ensureInitialized`, `authenticate`, `getActor`,
+ * `isAuthenticated`, `isInitializing`, `isSuccess`, `isError`) so it can be
+ * used outside React (for example in route guards).
  */
 export function createActorHook<T>(
   options: CreateActorHookOptions,
-): () => UseActorReturn<T> {
+): ActorHook<T> {
+  const hookId = nextHookId++;
   let _actor: ActorSubclass<T> | undefined;
 
-  // Create the store instance
+  // Initialization promise (resolves when initial anonymous actor is created)
+  let initializationResolve: ((actor?: ActorSubclass<T>) => void) | null = null;
+  let initializationReject: ((reason: Error) => void) | null = null;
+  let initializationPromise: Promise<ActorSubclass<T> | undefined> = new Promise<ActorSubclass<T> | undefined>((resolve, reject) => {
+    initializationResolve = resolve;
+    initializationReject = reject;
+  });
+
+  /**
+   * Create a fresh initialization promise.
+   *
+   * This promise is resolved when the anonymous actor has been created by
+   * `initializeActor()`. It's recreated on `reset()` so callers can await the
+   * next initialization cycle.
+   */
+  function createInitializationPromise() {
+    initializationPromise = new Promise<ActorSubclass<T> | undefined>((resolve, reject) => {
+      initializationResolve = resolve;
+      initializationReject = reject;
+    });
+  }
+
+  // Create the store instance using status strings (like ic-use-internet-identity)
   const store = createStore({
     context: {
       actor: undefined as ActorSubclass<T> | undefined,
-      isInitializing: false,
-      isAuthenticated: false,
+      status: "initializing" as ActorStatus,
       error: undefined as Error | undefined,
+      isAuthenticated: false,
     },
     on: {
-      setState: (
-        context: ActorStoreState<T>,
-        event: Partial<ActorStoreState<T>>,
-      ) => ({
+      setState: (context: ActorStoreState<T>, event: Partial<ActorStoreState<T>>) => ({
         ...context,
         ...event,
       }),
       reset: () => ({
         actor: undefined as ActorSubclass<T> | undefined,
-        isInitializing: false,
-        isAuthenticated: false,
+        status: "initializing" as ActorStatus,
         error: undefined as Error | undefined,
+        isAuthenticated: false,
       }),
     },
   });
 
-  // Initialize the actor immediately with an anonymous agent
-  // This allows the actor to be used for unauthenticated calls right away
+  /**
+   * Initialize the actor with an anonymous `HttpAgent`.
+   *
+   * Creates the actor instance immediately so components can make unauthenticated
+   * calls before an identity is attached. Resolves or rejects the internal
+   * initialization promise accordingly.
+   */
   const initializeActor = async () => {
     try {
-      store.send({ type: "setState" as const, isInitializing: true });
+      store.send({ type: "setState" as const, status: "initializing" });
 
       const shouldFetchRootKey = process.env.DFX_NETWORK !== "ic";
       const agent = await HttpAgent.create({
@@ -223,31 +262,71 @@ export function createActorHook<T>(
         ...options.actorOptions,
       });
 
+      // Store the actor (unproxied). Consumers can add interceptors later.
       store.send({
         type: "setState" as const,
         actor: _actor,
-        isInitializing: false,
-        isAuthenticated: false,
+        status: "success",
         error: undefined,
+        isAuthenticated: false,
       });
+
+      if (initializationResolve) {
+        initializationResolve(_actor);
+        initializationPromise = Promise.resolve(_actor);
+      }
     } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
       store.send({
         type: "setState" as const,
-        error: error instanceof Error ? error : new Error(String(error)),
-        isInitializing: false,
-        isAuthenticated: false,
+        status: "error",
+        error: err,
       });
+
+      if (initializationReject) {
+        initializationReject(err);
+        initializationPromise = Promise.reject(err);
+      }
     }
   };
 
-  // Initialize on creation
+  // Kick off initialization
   initializeActor();
 
-  // Authenticate function that replaces the anonymous identity with the provided one
-  // This allows the same actor instance to be used for authenticated calls
+  /**
+   * Wait for the initial anonymous actor initialization to complete.
+   *
+   * Resolves with the actor instance (or `undefined`) once initialization finishes,
+   * or throws if initialization failed.
+   */
+  const ensureInitialized = async (): Promise<ActorSubclass<T> | undefined> => {
+    const status = store.getSnapshot().context.status;
+
+    if (status === "error") {
+      const err = store.getSnapshot().context.error;
+      throw err ?? new Error("Initialization failed");
+    }
+
+    if (status !== "initializing") {
+      return store.getSnapshot().context.actor;
+    }
+
+    return initializationPromise;
+  };
+
+  /**
+   * Attach the provided `identity` to the actor's agent.
+   *
+   * Waits for initial initialization then replaces the agent identity so future
+   * calls are authenticated. This is synchronous from a network perspective
+   * (no network requests are made here) — it only mutates the agent.
+   *
+   * @param identity - Identity to attach to the actor
+   */
   const authenticate = async (identity: Identity) => {
     try {
-      store.send({ type: "setState" as const, isInitializing: true });
+      // Wait for initial actor to be ready first
+      await ensureInitialized();
 
       if (!_actor) {
         throw new Error("No actor found");
@@ -261,22 +340,26 @@ export function createActorHook<T>(
 
       store.send({
         type: "setState" as const,
-        isInitializing: false,
         isAuthenticated: true,
         error: undefined,
       });
     } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
       store.send({
         type: "setState" as const,
-        error: error instanceof Error ? error : new Error(String(error)),
-        isInitializing: false,
-        isAuthenticated: false,
+        status: "error",
+        error: err,
       });
+      throw err;
     }
   };
 
-  // Set up or update interceptors for request/response handling
-  // Interceptors are applied as a proxy over the existing actor
+  /**
+   * Apply request/response interceptors to the actor.
+   *
+   * Wraps the current actor instance in a proxy that invokes the provided
+   * interceptor callbacks around method calls.
+   */
   const setInterceptors = (interceptors: InterceptorOptions) => {
     try {
       if (!_actor) {
@@ -287,40 +370,117 @@ export function createActorHook<T>(
     } catch (error) {
       store.send({
         type: "setState" as const,
+        status: "error",
         error: error instanceof Error ? error : new Error(String(error)),
       });
     }
   };
 
-  // The hook that components will use to interact with the actor
-  return function useActor(): UseActorReturn<T> {
+  // Expose helpers for the registry and non-React helpers
+  /** Get the current (possibly proxied) actor instance from the store snapshot. */
+  const getActor = () => store.getSnapshot().context.actor;
+  /** Whether an identity has been attached to this actor (independent of init). */
+  const isAuthenticated = () => !!store.getSnapshot().context.isAuthenticated;
+  /** Predicate helper: whether the actor is currently initializing. */
+  const isInitializingHelper = () => store.getSnapshot().context.status === "initializing";
+  /** Predicate helper: whether the actor initialized successfully. See docs for isSuccess. */
+  const isSuccessHelper = () => store.getSnapshot().context.status === "success";
+  /** Predicate helper: whether the actor initialization failed. */
+  const isErrorHelper = () => store.getSnapshot().context.status === "error";
+
+  // Register this hook instance in the module-level registry
+  hookRegistry.set(hookId, {
+    id: hookId,
+    canisterId: options.canisterId,
+    ensureInitialized: ensureInitialized as unknown as () => Promise<ActorSubclass<any> | undefined>,
+    authenticate: authenticate as unknown as (identity: Identity) => Promise<void>,
+    getActor: getActor as unknown as () => ActorSubclass<any> | undefined,
+    isAuthenticated: isAuthenticated as unknown as () => boolean,
+  });
+
+  /**
+   * React hook exposed to components.
+   *
+   * Returns the actor instance and runtime helpers. For usage outside React
+   * (for example in route guards), use the helper methods attached to the hook
+   * function itself (e.g. `useMyActor.ensureInitialized()`).
+   */
+  function useActor(): UseActorReturn<T> {
     const actor = useSelector(store, (state) => state.context.actor);
-    const isInitializing = useSelector(
-      store,
-      (state) => state.context.isInitializing,
-    );
-    const isAuthenticated = useSelector(
-      store,
-      (state) => state.context.isAuthenticated,
-    );
+    const status = useSelector(store, (state) => state.context.status);
     const error = useSelector(store, (state) => state.context.error);
+    const isAuthenticated = useSelector(store, (state) => state.context.isAuthenticated);
 
     return {
       actor,
-      isInitializing,
+      status,
+      isInitializing: status === "initializing",
+      isSuccess: status === "success",
+      isError: status === "error",
       isAuthenticated,
       error,
       authenticate,
       setInterceptors,
       reset: () => {
+        // Dispose and recreate initialization promise
         _actor = undefined;
+        createInitializationPromise();
         store.send({ type: "reset" as const });
         initializeActor();
       },
-      clearError: () =>
-        store.send({ type: "setState" as const, error: undefined }),
+      clearError: () => store.send({ type: "setState" as const, error: undefined }),
     };
-  };
+  }
+
+  // Attach non-react helpers directly to the hook function so consumers can call them outside React
+  const useActorWithHelpers = Object.assign(useActor, {
+    ensureInitialized,
+    authenticate,
+    getActor,
+    isAuthenticated,
+    isInitializing: isInitializingHelper,
+    isSuccess: isSuccessHelper,
+    isError: isErrorHelper,
+  }) as ActorHook<T>;
+
+  return useActorWithHelpers;
+}
+
+/**
+ * Ensure all registered hooks have completed initialization.
+ * Useful when you have multiple canister hooks and want to wait for them in a route guard.
+ */
+export async function ensureAllInitialized(): Promise<void> {
+  const items = Array.from(hookRegistry.values());
+  await Promise.all(items.map((it) => it.ensureInitialized()));
+}
+
+/**
+ * Authenticate all registered hooks with the given identity.
+ * Optionally filter by a list of canister IDs.
+ * Throws if any hook fails to authenticate.
+ */
+export async function authenticateAll(
+  identity: Identity,
+  filterCanisterIds?: string[],
+): Promise<void> {
+  const items = Array.from(hookRegistry.values()).filter(
+    (it) => !filterCanisterIds || filterCanisterIds.includes(it.canisterId),
+  );
+
+  const results = await Promise.allSettled(items.map((it) => it.authenticate(identity)));
+  const failed = results.filter((r) => r.status === "rejected");
+  if (failed.length) {
+    const reasons = failed.map((r) => (r as PromiseRejectedResult).reason).join("; ");
+    throw new Error(`authenticateAll failed for ${failed.length} hooks: ${reasons}`);
+  }
+}
+
+/**
+ * Authenticate hooks for a single canister id only.
+ */
+export async function authenticateCanister(identity: Identity, canisterId: string): Promise<void> {
+  await authenticateAll(identity, [canisterId]);
 }
 
 /**
@@ -331,7 +491,7 @@ export const createUseActorHook = createActorHook;
 /**
  * @deprecated Context-based actors are no longer needed. Use `createActorHook` instead.
  */
-export function createActorContext<T>() {
+export function createActorContext() {
   console.warn(
     "createActorContext is deprecated. Use createActorHook instead.",
   );
@@ -345,3 +505,4 @@ export function ActorProvider(_props: any) {
   console.warn("ActorProvider is deprecated. Use createActorHook instead.");
   return null;
 }
+

--- a/src/interceptor-data.type.ts
+++ b/src/interceptor-data.type.ts
@@ -12,17 +12,19 @@ export type InterceptorErrorData = {
 
 /**
  * Interceptor options for customizing actor request/response handling
+ *
+ * All callbacks may return a value or a Promise — async handlers are supported.
  */
 export interface InterceptorOptions {
-  /** Callback function that will be called before the request is sent. Should return the modified arguments array. */
-  onRequest?: (data: InterceptorRequestData) => unknown[];
+  /** Callback called before the request is sent. May return modified arguments array (sync or Promise). */
+  onRequest?: (data: InterceptorRequestData) => unknown[] | Promise<unknown[]>;
 
-  /** Callback function that will be called after a successful response is received. Should return the modified response. */
-  onResponse?: (data: InterceptorResponseData) => unknown;
+  /** Callback called after a successful response is received. May return modified response (sync or Promise). */
+  onResponse?: (data: InterceptorResponseData) => unknown | Promise<unknown>;
 
-  /** Callback function that will be called when a TypeError occurs during the request. Should return the modified error. */
-  onRequestError?: (data: InterceptorErrorData) => Error | TypeError | unknown;
+  /** Callback called when an error occurs during request setup. May return a replacement error or throw. */
+  onRequestError?: (data: InterceptorErrorData) => unknown | Promise<unknown>;
 
-  /** Callback function that will be called when an error occurs during the response. Should return the modified error. */
-  onResponseError?: (data: InterceptorErrorData) => Error | TypeError | unknown;
+  /** Callback called when an error occurs during the response. May return a replacement error or throw. */
+  onResponseError?: (data: InterceptorErrorData) => unknown | Promise<unknown>;
 }


### PR DESCRIPTION
## [0.3.0] - 2025-09-15

### General

- v0.3.0 focuses on smoother app integration and orchestration across multiple canisters. It adds non-React helpers and global utilities so you can gate routes, authenticate many actors at once, and reliably check initialization/auth state without wiring extra context or providers. Docs now include a router-first flow.

### Key Features
- Unified runtime status: New `status` plus `isInitializing/isSuccess/isError`.
- Non-React helpers: Call `ensureInitialized`, `authenticate`, `getActor`, and status predicates outside components.
- Global orchestration: `ensureAllInitialized`, `authenticateAll`, and `authenticateCanister` coordinate many hooks.
- Router integration docs: Example guard flow with TanStack Router for predictable startup and auth, no `useEffect` in sight.

Example (route guard flow):
```ts
const identity = await ensureIdentityInitialized(); // from ic-use-internet-identity
if (!identity) throw redirect({ to: "/login" });

await ensureAllInitialized();     // wait for all actor hooks to finish anonymous init
await authenticateAll(identity);  // attach identity to all registered hooks
```

### Added
- Status + flags: `status: "initializing" | "success" | "error"` and derived booleans.
- Per-hook helpers (non-React): `useMyActor.ensureInitialized()`, `useMyActor.authenticate(identity)`, `useMyActor.getActor()`, `useMyActor.isAuthenticated()` and predicates for status.
- Global helpers: `ensureAllInitialized()`, `authenticateAll(identity, filter?)`, `authenticateCanister(identity, canisterId)`.
- Router example: End-to-end “beforeLoad” example covering identity restore → actor init → authentication

### Fixed
- Docs clarity: Clear separation of initialization vs. authentication; `error` now documented as “initialization only”.
- Interceptor ergonomics: Example shows handling “delegation expired” with app hooks, without polluting init error state.
- Minor typos and examples: Cleaned and tightened API examples, consistent naming.

### Migration
- From v0.2.x → v0.3.0: No breaking changes. You can adopt:
  - `status` and the derived flags for simpler UI state.
  - Non-React helpers in guards, loaders, or services.
  - Global helpers to authentically attach identity across many hooks at once.

### Important Notes
- Initialization vs auth: `isSuccess` means “actor created”; it does NOT imply authenticated. Check `isAuthenticated`.
- Identity first: Always await your identity library’s init before initializing/authenticating actors in guards.
- Auth is local: `authenticate(identity)` mutates the agent’s identity; it doesn’t perform a network request.
- Multiple canisters: Either authenticate each hook or use `authenticateAll(identity)`; you can filter by canister id.
- Errors: The exposed `error` is reserved for initialization failures; interceptor/auth errors won’t set it.
